### PR TITLE
Update assetlinks.json

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -11,7 +11,7 @@
     "namespace": "android_app",
     "package_name": "dev.jeran.autofill",
     "sha256_cert_fingerprints": [
-      "E1:85:BC:42:09:3C:26:CC:39:15:60:D9:D0:83:DA:EE:88:88:6D:53:CF:62:66:95:05:35:63:4B:26:5F:B9:DB"
+      "5D:44:F0:5A:4F:72:EA:95:E1:56:54:31:62:56:6F:60:B5:68:FD:B5:45:72:01:9F:DE:78:DA:F2:FF:80:BF:25", "E1:85:BC:42:09:3C:26:CC:39:15:60:D9:D0:83:DA:EE:88:88:6D:53:CF:62:66:95:05:35:63:4B:26:5F:B9:DB"
     ]
   }
  }]


### PR DESCRIPTION
Add Google Play generated sha. I forgot to update the app signing certificate on Google Play to my locally generated one. This update changes assetlinks.json to include both the original Google Play generated one as well as my locally generated one, which is now supposed to be used for all future app signings.